### PR TITLE
Add pkgconfig file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ tests/perftests/hello_no_launcher/hello_no_launcher
 tests/perftests/launcher_perf.txt
 build-stamp
 configure-stamp
+build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,16 @@
-project(Applauncherd)
+cmake_minimum_required(VERSION 3.0)
+cmake_policy(VERSION 3.0)
 
-cmake_minimum_required(VERSION 2.6)
-cmake_policy(VERSION 2.6)
+project(Applauncherd
+	VERSION 4.1.43
+	DESCRIPTION "A daemon that helps to launch applications faster")
+
+find_package(ECM REQUIRED NO_MODULE)
+set(CMAKE_MODULE_PATH ${ECM_MODULE_PATH})
 
 include(FeatureSummary)
 include(GNUInstallDirs)
+include(ECMGeneratePkgConfigFile)
 
 option(INSTALL_SYSTEMD_UNITS "Install systemd unit files" ON)
 

--- a/rpm/mapplauncherd.spec
+++ b/rpm/mapplauncherd.spec
@@ -10,6 +10,7 @@ Requires:   systemd-user-session-targets
 Requires(post): /sbin/ldconfig
 Requires(postun): /sbin/ldconfig
 Requires(pre):  sailfish-setup
+BuildRequires:  extra-cmake-modules
 BuildRequires:  pkgconfig(libshadowutils)
 BuildRequires:  pkgconfig(systemd)
 BuildRequires:  pkgconfig(dbus-1)
@@ -93,6 +94,7 @@ install -D -m 0755 scripts/booster-cgroup-mount %{buildroot}/usr/lib/startup/boo
 %files devel
 %defattr(-,root,root,-)
 %{_includedir}/applauncherd/*
+%{_libdir}/pkgconfig/*.pc
 
 %files cgroup
 %{_unitdir}/booster-cgroup-mount.service

--- a/src/launcherlib/CMakeLists.txt
+++ b/src/launcherlib/CMakeLists.txt
@@ -1,5 +1,3 @@
-include(GNUInstallDirs)
-
 set(COMMON ${CMAKE_HOME_DIRECTORY}/src/common)
 
 # Find systemd
@@ -29,12 +27,24 @@ set(HEADERS appdata.h booster.h connection.h daemon.h logger.h launcherlib.h
 link_libraries(${GLIB_LDFLAGS} ${DBUS_LDFLAGS} ${LIBDL} "-L/lib -lsystemd -lcap")
 
 # Set executable
-add_library(applauncherd MODULE ${SRC} ${MOC_SRC})
-set_target_properties(applauncherd PROPERTIES VERSION 0.1 SOVERSION 0)
-
+add_library(applauncherd SHARED ${SRC} ${MOC_SRC})
 target_link_libraries(applauncherd ${SYSTEMD_LIBRARIES})
 
+set_target_properties(applauncherd PROPERTIES
+    VERSION ${PROJECT_VERSION}
+    SOVERSION ${PROJECT_VERSION_MAJOR})
+
+# Configure and install the pkgconfig file
+ecm_generate_pkgconfig_file(
+	BASE_NAME applauncherd
+	FILENAME_VAR applauncherd
+	DESCRIPTION ${PROJECT_DESCRIPTION}
+	INSTALL)
+
 # Add install rule
-install(TARGETS applauncherd DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR})
-install(FILES ${HEADERS} DESTINATION ${CMAKE_INSTALL_FULL_INCLUDEDIR}/applauncherd
-  PERMISSIONS OWNER_READ GROUP_READ WORLD_READ)
+install(TARGETS applauncherd
+    LIBRARY DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR})
+install(FILES ${HEADERS}
+    DESTINATION ${CMAKE_INSTALL_FULL_INCLUDEDIR}/applauncherd
+    COMPONENT Devel
+    PERMISSIONS OWNER_READ GROUP_READ WORLD_READ)


### PR DESCRIPTION
Without this pkgconfig file, -lapplauncherd is undefined and it can not be used to compile other applications with it. I needed this to get mapplauncherd-qt to compile and I'm not sure how you guys had it working without it 🤔

This is a recreation of https://git.sailfishos.org/mer-core/mapplauncherd/merge_requests/23 as sadly you guys are moving away from the FOSS Gitlab. Please check there for any existing comments.