### PR TITLE
Fix build on Musl libc systems

### DIFF
--- a/src/launcherlib/CMakeLists.txt
+++ b/src/launcherlib/CMakeLists.txt
@@ -24,7 +24,7 @@ set(HEADERS appdata.h booster.h connection.h daemon.h logger.h launcherlib.h
 
 # Set libraries to be linked. Shared libraries to be preloaded are not linked in anymore,
 # but dlopen():ed and listed in src/launcher/preload.h instead.
-link_libraries(${GLIB_LDFLAGS} ${DBUS_LDFLAGS} ${LIBDL} "-L/lib -lsystemd -lcap")
+link_libraries(${GLIB_LDFLAGS} ${DBUS_LDFLAGS} ${LIBDL} "-L/lib -lcap")
 
 # Set executable
 add_library(applauncherd SHARED ${SRC} ${MOC_SRC})

--- a/src/launcherlib/daemon.cpp
+++ b/src/launcherlib/daemon.cpp
@@ -43,6 +43,7 @@
 #include <stdexcept>
 #include <fstream>
 #include <sstream>
+#include <libgen.h>
 #include <stdlib.h>
 #include <systemd/sd-daemon.h>
 #include <unistd.h>
@@ -979,7 +980,8 @@ void Daemon::parseArgs(int argc, char **argv)
 // Prints the usage and exits with given status
 void Daemon::usage(const char *name, int status)
 {
-    name = basename(name);
+    char *nameCopy = strdup(name);
+    name = basename(nameCopy);
     printf("\n"
            "Start the application launcher daemon.\n"
            "\n"
@@ -1007,6 +1009,8 @@ void Daemon::usage(const char *name, int status)
            "                   Make diagnostic logging more verbose.\n"
            "\n",
            name, name, name);
+
+    free(nameCopy);
 
     exit(status);
 }


### PR DESCRIPTION
Make sure we use the POSIX basename rather than GNU's.
When we include libgen.h, POSIX's basename will be used rather than
GNU's. Since we don't use the special functionalities of GNU's variant
anyway, this helps to compile it on POSIX-compliant libc's like Musl.

Don't link to systemd twice.
We link (in a proper CMake way) later a bit below this line, and that
actually works on systems using e.g. elogind too.