### PR TITLE
Sandbox apps when requested

### DIFF
--- a/src/common/sailjail.h
+++ b/src/common/sailjail.h
@@ -6,7 +6,11 @@
 
 G_BEGIN_DECLS
 
+#define SAILJAIL_PATH "/usr/bin/sailjail"
+
 bool sailjail_verify_launch(const char *desktop, const char **argv);
+
+bool sailjail_sandbox(const char *desktop);
 
 G_END_DECLS
 

--- a/src/invoker/CMakeLists.txt
+++ b/src/invoker/CMakeLists.txt
@@ -3,12 +3,13 @@ set(COMMON "${CMAKE_HOME_DIRECTORY}/src/common")
 # Find dbus
 include(FindPkgConfig)
 pkg_check_modules(DBUS dbus-1 REQUIRED)
+pkg_check_modules(GLIB glib-2.0 REQUIRED)
 
 # Set sources
-set(SRC invokelib.c invoker.c ${COMMON}/report.c search.c)
+set(SRC invokelib.c invoker.c ${COMMON}/report.c search.c ${COMMON}/sailjail.c)
 
 # Set include dirs
-include_directories(${CMAKE_CURRENT_SOURCE_DIR} ${DBUS_INCLUDE_DIRS} ${COMMON})
+include_directories(${CMAKE_CURRENT_SOURCE_DIR} ${DBUS_INCLUDE_DIRS} ${GLIB_INCLUDE_DIRS} ${COMMON})
 
 # Set precompiler flags
 add_definitions(-DPROG_NAME_INVOKER="invoker")
@@ -16,7 +17,7 @@ add_definitions(-DPROG_NAME_INVOKER="invoker")
 # Set target
 add_executable(invoker ${SRC})
 
-target_link_libraries(invoker ${DBUS_LDFLAGS})
+target_link_libraries(invoker ${DBUS_LDFLAGS} ${GLIB_LDFLAGS})
 
 # Add install rule
 install(TARGETS invoker DESTINATION ${CMAKE_INSTALL_FULL_BINDIR})

--- a/src/launcherlib/appdata.h
+++ b/src/launcherlib/appdata.h
@@ -72,6 +72,9 @@ public:
     //! Set address of the argument vector
     void setArgv(const char ** argv);
 
+    //! Prepend to argv
+    void prependArgv(const char *arg);
+
     //! Return address of the argument vector
     const char ** argv() const;
 


### PR DESCRIPTION
Forces use of generic booster when it detects that application should be
sandboxed but it is not launched via sailjail already and prepends
sailjail argument already in invoker.

Check before executing in booster if the arguments don't contain sailjaild
and the if the app should be launched in a sandbox. In that case prepend
the arguments with sailjail.