### PR TITLE
Run all applications with nice 0.

### DIFF
--- a/src/launcherlib/booster.cpp
+++ b/src/launcherlib/booster.cpp
@@ -90,8 +90,8 @@ void Booster::initialize(int initialArgc, char ** initialArgv, int newBoosterLau
 
     setBoosterLauncherSocket(newBoosterLauncherSocket);
 
-    // Drop priority (nice = 10)
-    pushPriority(10);
+    // Set nice value (priority) to default for all apps
+    pushPriority(0);
 
     // Preload stuff
     if (!m_bootMode)


### PR DESCRIPTION
The nice priority 10 has been there for 15 years without any explanation, see commit d18c8d95ef6a2af5a88181e2414f263c8bf49331 and any that moves it around. Return to normal and to run all applications with nice 0.