### PR TITLE
[mapplauncherd] Remove bad comparison. JB#63168

### DIFF
--- a/src/invoker/invoker.c
+++ b/src/invoker/invoker.c
@@ -635,7 +635,7 @@ static unsigned int get_delay(char *delay_arg, char *param_name,
         delay = strtoul(delay_arg, NULL, 10);
 
         // Check for various possible errors
-        if ((errno == ERANGE && delay == ULONG_MAX)
+        if (errno == ERANGE
             || delay < min_value
             || delay > max_value)
         {


### PR DESCRIPTION
Delay gets cast into unsigned int so it can't be equal to ULONG_MAX. The check shouldn't be even needed since errno should already tell that something went wrong.