### PR TITLE
Drop priority adjustment

### DIFF
--- a/rpm/mapplauncherd.spec
+++ b/rpm/mapplauncherd.spec
@@ -18,8 +18,6 @@ BuildRequires:  pkgconfig(dbus-1)
 BuildRequires:  pkgconfig(libcap)
 BuildRequires:  pkgconfig(glib-2.0)
 BuildRequires:  cmake
-Provides:   meegotouch-applauncherd > 3.0.3
-Obsoletes:   meegotouch-applauncherd <= 3.0.3
 
 %description
 Application invoker and launcher daemon that speed up
@@ -30,8 +28,6 @@ functionality to launch applications as single instances.
 %package devel
 Summary:    Development files for launchable applications
 Requires:   %{name} = %{version}-%{release}
-Provides:   meegotouch-applauncherd-devel > 3.0.3
-Obsoletes:  meegotouch-applauncherd-devel <= 3.0.3
 
 %description devel
 Development files for creating applications that can be launched
@@ -79,7 +75,6 @@ install -D -m 0755 scripts/booster-cgroup-mount %{buildroot}/usr/lib/startup/boo
 %postun -p /sbin/ldconfig
 
 %files
-%defattr(-,root,root,-)
 %license COPYING.LESSER
 %dir %{_datadir}/mapplauncherd
 %dir %{_datadir}/mapplauncherd/privileges.d
@@ -92,7 +87,6 @@ install -D -m 0755 scripts/booster-cgroup-mount %{buildroot}/usr/lib/startup/boo
 %{_userunitdir}/user-session.target.wants/booster-generic.service
 
 %files devel
-%defattr(-,root,root,-)
 %{_includedir}/applauncherd/*
 %{_libdir}/libapplauncherd.so
 %{_libdir}/pkgconfig/*.pc

--- a/src/launcherlib/appdata.h
+++ b/src/launcherlib/appdata.h
@@ -99,7 +99,7 @@ public:
     //! Set booster respawn delay
     void setDelay(int delay);
 
-    //!Return respawn delay
+    //! Return respawn delay
     int delay() const;
 
     //! Set entry point for the application

--- a/src/launcherlib/booster.cpp
+++ b/src/launcherlib/booster.cpp
@@ -65,8 +65,6 @@ static std::string basename(const std::string &str)
 Booster::Booster() :
     m_appData(new AppData),
     m_connection(NULL),
-    m_oldPriority(0),
-    m_oldPriorityOk(false),
     m_spaceAvailable(0),
     m_boostedApplication("default"),
     m_bootMode(false)
@@ -90,9 +88,6 @@ void Booster::initialize(int initialArgc, char ** initialArgv, int newBoosterLau
 
     setBoosterLauncherSocket(newBoosterLauncherSocket);
 
-    // Drop priority (nice = 10)
-    pushPriority(10);
-
     // Preload stuff
     if (!m_bootMode)
         preload();
@@ -103,9 +98,6 @@ void Booster::initialize(int initialArgc, char ** initialArgv, int newBoosterLau
     temporaryProcessName += "]";
     const char * tempArgv[] = {temporaryProcessName.c_str()};
     renameProcess(initialArgc, initialArgv, 1, tempArgv);
-
-    // Restore priority
-    popPriority();
 
     while (true)
     {
@@ -572,34 +564,6 @@ void* Booster::loadMain()
                                  error_s + "'\n");
 
     return module;
-}
-
-bool Booster::pushPriority(int nice)
-{
-    errno = 0;
-    m_oldPriorityOk = true;
-    m_oldPriority   = getpriority(PRIO_PROCESS, getpid());
-
-    if (errno)
-    {
-        m_oldPriorityOk = false;
-    }
-    else
-    {
-        return setpriority(PRIO_PROCESS, getpid(), nice) != -1;
-    }
-
-    return false;
-}
-
-bool Booster::popPriority()
-{
-    if (m_oldPriorityOk)
-    {
-        return setpriority(PRIO_PROCESS, getpid(), m_oldPriority) != -1;
-    }
-
-    return false;
 }
 
 const string &Booster::boostedApplication() const

--- a/src/launcherlib/booster.h
+++ b/src/launcherlib/booster.h
@@ -165,7 +165,7 @@ protected:
      *  initializations can be done here.
      *  Re-implement if needed.
      */
-    virtual void preinit() {};
+    virtual void preinit() {}
 
     //! Sets the socket fd used in the communication between
     //! the booster and launcher.

--- a/src/launcherlib/booster.h
+++ b/src/launcherlib/booster.h
@@ -167,12 +167,6 @@ protected:
      */
     virtual void preinit() {};
 
-    //! Set nice value and store the old priority. Return true on success.
-    bool pushPriority(int nice);
-
-    //! Restore the old priority stored by the previous successful setPriority().
-    bool popPriority();
-
     //! Sets the socket fd used in the communication between
     //! the booster and launcher.
     void setBoosterLauncherSocket(int boosterLauncherSocket);
@@ -206,13 +200,6 @@ private:
 
     //! Socket connection to invoker
     Connection* m_connection;
-
-    //! Process priority before pushPriority() is called
-    int m_oldPriority;
-
-    //! True if m_oldPriority is a valid value so that
-    //! it can be restored later.
-    bool m_oldPriorityOk;
 
     //! Socket used to tell the parent that a new booster is needed
     int m_boosterLauncherSocket;


### PR DESCRIPTION
Ref https://github.com/sailfishos/mapplauncherd/pull/16 did some investigation and then just dropped the priority adjustments. Not expecting that big benefit these days anyway.

Main commit:

    [mapplauncherd] Avoid attempting to lower priorities while initializing. JB#62296
    
    Restoring the priorities with setpriority() was getting permission error
    while setting priority back to 0. There seemed some suspicious
    details:
    - Sailfish has been settings /etc/systemd/user.conf - DefaultLimitNICE=1
    now a couple years, JB#57806, related to some journal flood.
    Not sure how that 1 was better than earlier 0 at this point.
    Also setting config 0 still produced permission error.
    - setpriority() was using getpid() instead of 0. Tried that to rule out
    funny details with our permission adjustments but no help though.
    
    Anyhow with current multi-core devices handling background
    initialization better than past days, let's just drop this.
    Simple is good.

